### PR TITLE
[fix] Added feature to keep track of the Currently Opened Section

### DIFF
--- a/WebApplication2/Customer/Pages/CustomerComponent.aspx
+++ b/WebApplication2/Customer/Pages/CustomerComponent.aspx
@@ -600,9 +600,12 @@
         function showSection(id) {
             document.querySelectorAll('.content').forEach(el => el.style.display = 'none');
             document.getElementById(id).style.display = 'block';
+    
+            // Save the current section to localStorage
+            localStorage.setItem('activeSection', id);
         }
 
-        // Dark Mode Toggle
+
         // Dark Mode Toggle
         function toggleDarkMode() {
             const body = document.body;
@@ -662,7 +665,10 @@
             });
         });
 
-        window.onload = () => showSection('servicePlans');
+        document.addEventListener("DOMContentLoaded", function () {
+            const activeSection = localStorage.getItem('activeSection') || 'servicePlans';
+            showSection(activeSection);
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Description

As previously mentioned in issue #8, we did not correctly keep track of the Currently Open Section State which led to the bug of the Section changing whenever one of the `styled-button`(s) is pushed. I fixed this by adding the corresponding JavaScript Methods that allow us to keep track of which section is currently open and to only change that section whenever the user willingly opens another section. We can only have one open section at a time since there is only one viewing panel for the Currently Open Section.

## Screenshots

### Before fixing the Bug
![Image](https://github.com/user-attachments/assets/5f4c8bf6-25f6-4677-bc11-1c79fb1c81c7)
---
![Image](https://github.com/user-attachments/assets/1f6ad04c-856d-4c63-bf4a-6b19e06e8c72)
### After fixing the Bug
![image](https://github.com/user-attachments/assets/b3bc7174-e440-4d65-9c13-224243e9841f)
---
![image](https://github.com/user-attachments/assets/8af699c0-1f7b-4385-bbb6-49e6a3963130)

### The website now behaves as expected when it comes to keeping track of Section States.