### PR TITLE
[fix] Reorganized the `SMS, Minutes, and Internet Consumption Section`

### DIFF
--- a/WebApplication2/Customer/Pages/CustomerComponent.aspx
+++ b/WebApplication2/Customer/Pages/CustomerComponent.aspx
@@ -475,9 +475,13 @@
      <div id="sms-minutes-internet" class="content">
          <h2>SMS, Minutes, and Internet Consumption</h2>
          <form id="form1" runat="server">
-         
+         <h3>Enter Plan Name: </h3>
          <asp:TextBox ID="planName" runat="server" placeholder="Enter Plan Name" CssClass="styled-textbox"></asp:TextBox>
+         <br />
+         <h3>Enter Start Date: </h3>
          <asp:TextBox ID="startDate" runat="server" TextMode="Date" placeholder="Start Date" CssClass="styled-textbox"></asp:TextBox>
+         <br />
+         <h3>Enter End Date: </h3>
          <asp:TextBox ID="endDate" runat="server" TextMode="Date" placeholder="End Date" CssClass="styled-textbox"></asp:TextBox>
          <asp:Label ID="lblSMS" runat="server"></asp:Label>
          <asp:Label ID="lblMins" runat="server"></asp:Label>


### PR DESCRIPTION
## Description

As previously mentioned in issue #12, this PR is concerning making said Section more clear and User-friendly such that a more broad variety of users can easily understand what they need to do to see their Data Consumption.

## Screenshots
### Before Reorganization
![image](https://github.com/user-attachments/assets/38674a03-e692-4daa-bcae-8935a0c4b910)
### After Reorganization
![Screenshot 2025-02-09 190302](https://github.com/user-attachments/assets/a636d7cf-a2b9-413e-8a21-10e22874c572)
