### PR TITLE
[fix] Reorganize result labels and enable Dark Mode for the Calendar assigned for TextBoxes of type `Date`.

### DIFF
--- a/WebApplication2/Customer/Pages/CustomerComponent.aspx
+++ b/WebApplication2/Customer/Pages/CustomerComponent.aspx
@@ -175,6 +175,7 @@
             text-align: center;
             display: inline-block;
             margin-bottom: 20px;
+            margin-right:  15px;
             font-weight:500;
         }
             .dark-mode .number-box {
@@ -272,6 +273,10 @@
         .styled-textbox:focus {
             border-color: #0078d4;
             box-shadow: 0 0 5px rgba(0, 120, 212, 0.5);
+        }
+
+        .dark-mode .styled-textbox {
+        color-scheme: dark;
         }
 
         body.dark-mode .styled-textbox {
@@ -483,6 +488,7 @@
          <br />
          <h3>Enter End Date: </h3>
          <asp:TextBox ID="endDate" runat="server" TextMode="Date" placeholder="End Date" CssClass="styled-textbox"></asp:TextBox>
+         <br />
          <asp:Label ID="lblSMS" runat="server"></asp:Label>
          <asp:Label ID="lblMins" runat="server"></asp:Label>
          <asp:Label ID="lblInt" runat="server"></asp:Label>


### PR DESCRIPTION
## Description

This PR solves both issue #14 and #15. As previously mentioned, the issue #14 is concerning the incomplete reorganization of the `SMS, Minutes, and Internet Consumption` Section by changing the place of the result labels to their correct places. As for issue #15, we've established the fact that **Dark Mode** is not enabled for the Calendar assigned for TextBoxes of type `Date`, _even when **Dark Mode** is enabled on the website itself._

## Screenshots
### Before Solving both issues
![Image](https://github.com/user-attachments/assets/5630b03f-8dfc-4290-a5be-fcebd0b31413)
![Image](https://github.com/user-attachments/assets/2826e18d-9b4b-4401-abd7-b45a24a8e0f5)
### After Solving both issues
![image](https://github.com/user-attachments/assets/7e7016c0-1246-4c2e-ad45-8a3329015997)
![image](https://github.com/user-attachments/assets/6d53a25b-f9e9-4526-9536-ddf03baabd64)
