### PR TITLE
[fix] Fix nav-links alignment for better responsiveness.

### DIFF
--- a/WebApplication2/Customer/Pages/CustomerComponent.aspx
+++ b/WebApplication2/Customer/Pages/CustomerComponent.aspx
@@ -51,7 +51,8 @@
         }
 
         header .nav-links {
-            margin-left: 400px;
+            margin-left: auto;
+            margin-right: 25px;
             display: flex;
             gap: 20px;
             justify-content: flex-end;
@@ -159,7 +160,7 @@
             margin-bottom: 20px;
             color: #606060; 
         }
-         .dark-mode  .content h2 {
+        .dark-mode  .content h2 {
             font-size: 26px;
             font-weight: 600;
             margin-bottom: 20px;


### PR DESCRIPTION
## Description

This PR closes issue #17 concerning the misalignment of the nav-links on Bigger Screens. I have solved the issue by changing the CSS Style for the nav-links from 

```css 
margin-left: 400px;
```` 
to 
```css 
margin-left: auto;
margin-right: 25px;
```
### Automating the left margin and adding an additional right margin to distance the nav-links from the **Dark Mode** Toggle Button.

## Screenshots
### Before Automating the left margin

![Image](https://github.com/user-attachments/assets/755eaa29-79d8-44db-8559-565ee365c780)

### Notice how the nav-links are so close to the Dark Mode Toggle Button

### After Automating the left margin

![image](https://github.com/user-attachments/assets/f74a06c1-cd5b-4e9a-881c-7db0e22916f8)

### Adding the extra right margin (Final View)

![image](https://github.com/user-attachments/assets/bc418e12-3ae9-4756-9dbe-bf2fa3c4260a)

### This issue is now solved, aligning the nav-links for all Screen Sizes automatically and adding a right margin to distance the nav-links from the Toggle Button.