### PR TITLE
[fix] Enhance Hint Pop-up placement for visual consistency.

### DIFF
--- a/WebApplication2/Customer/Pages/CustomerComponent.aspx
+++ b/WebApplication2/Customer/Pages/CustomerComponent.aspx
@@ -410,7 +410,7 @@
         .hint-popup {
             position: fixed;
             bottom: 20px;
-            right: 20px;
+            right: 30px;
             width: 300px;
             background-color: #fff;
             border: 1px solid #ccc;


### PR DESCRIPTION
## Description

This PR closes issue #19 concerning the ill-placement of the Hint Pop-up which could be improved to showcase all of the UI Elements clearly in harmony together. Upon fixing this issue, I've decided to change the CSS Style

```css 
        .hint-popup {
            position: fixed;
            bottom: 20px;
            right: 20px;
```
to 
```css 
        .hint-popup {
            position: fixed;
            bottom: 20px;
            right: 30px;
```
### Changing the right position to move the Pop-up 10 pixels more to the left to showcase both the background as well as the `content` section.

## Screenshots
### Before Moving the Pop-up to the Left

![Image](https://github.com/user-attachments/assets/5f43acf0-5364-48ee-b2ef-1a2673767727)

### Notice how the Hint Pop-up is perfectly aligned to the `content` section, it doesn't look quite right especially with the round edges.

### After Moving the Pop-up to the Left

![image](https://github.com/user-attachments/assets/e8182443-4711-45a3-8476-6299fac7eb17)
![image](https://github.com/user-attachments/assets/dced28f4-092e-4430-bf32-d9442c17e3f9)


### This issue is now solved, changing the placement of the Hint Pop-up to showcase all of the UI elements and eliminating the odd look of perfect alignment.

Would appreciate feedback on this approach.